### PR TITLE
[FIX] views.edit: set views as active when using `edit_views`

### DIFF
--- a/src/custom_util/views/edit.py
+++ b/src/custom_util/views/edit.py
@@ -112,7 +112,7 @@ def edit_views(
         if not operations:  # silently skip views with no operations
             continue
         for view_id in views_ids_map[id_origin]:
-            with util.edit_view(cr, view_id=view_id, skip_if_not_noupdate=False) as arch:
+            with util.edit_view(cr, view_id=view_id, skip_if_not_noupdate=False, active=True) as arch:
                 _logger.log(
                     logging.INFO if verbose else logging.DEBUG,
                     f'Patching ir.ui.view "{id_origin}" (id={view_id})',


### PR DESCRIPTION
### Description

After the merge of odoo/upgrade-util@e65d655, the function `edit_views` was not activating the views like it used to do.

This commit restores the old behaviour.
