### PR TITLE
[FIX] views.edit: mute logger for MockRequest

### DIFF
--- a/src/custom_util/views/edit.py
+++ b/src/custom_util/views/edit.py
@@ -7,6 +7,8 @@ import logging
 from lxml import etree
 from psycopg2.extras import execute_values
 
+from odoo.tools.misc import mute_logger
+
 from odoo.upgrade import util
 
 from ..helpers import toggle_active
@@ -382,7 +384,6 @@ def set_studio_view(cr, path, inherit_xml_id):
     :param path: the xml file from which to load the new elements.
     :param inherit_xml_id: the id of the view to inherit from.
     """
-
     env = util.env(cr)
 
     if "web_studio" not in env.registry._init_modules:
@@ -394,10 +395,10 @@ def set_studio_view(cr, path, inherit_xml_id):
 
     controller = WebStudioController()
     inherit_view = env.ref(inherit_xml_id)
-    with open(path, "r", encoding="utf-8") as data:
+    with open(path, encoding="utf-8") as data:
         xml_data = data.read()
 
-    with MockRequest(env, context=dict(studio=True)):
+    with mute_logger("odoo.tests.common"), MockRequest(env, context=dict(studio=True)):
         return controller._set_studio_view(inherit_view, xml_data)
 
 


### PR DESCRIPTION
### Description

In `18.0`, an `error` is logged from `odoo.tests.common` if imported outside of `test` mode. Mute this when importing `MockRequest` for use with Studio views.

### All Submissions:

* [x] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [x] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [x] I have used pre-commit
* [x] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [ ] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [ ] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 

### Maintenance reminders:

* Always bump the version of the manifest on the affected modules.
* Notify the developer responsible for the initial development task (when this is relevant).
