### PR TITLE
[FIX] views.misc: traceback in `get_views_ids()` with `keys`

### DIFF
--- a/src/custom_util/views/misc.py
+++ b/src/custom_util/views/misc.py
@@ -225,7 +225,7 @@ def get_views_ids(
             view_keys.add(value)
             return None
         if coerce_str and isinstance(value, str):
-            view_keys.add(ViewKey(key, website_id))
+            view_keys.add(ViewKey(value, website_id))
             return None
         if isinstance(value, Collection) and not isinstance(value, str):
             # recurse to add view_keys to set and convert them to None in the iterable
@@ -233,7 +233,7 @@ def get_views_ids(
             return [v for v in value if v is not None]
         return value
 
-    get_view_keys(keys, coerce_str=True)
+    keys = get_view_keys(keys, coerce_str=True)
     assert not keys, "all keys should have been consumed, otherwise got unhandled types"
     views = get_view_keys(views)
     more_views = get_view_keys(more_views)


### PR DESCRIPTION
### Description

Traceback in `get_views_ids()` when passing in the `keys` parameter for COW website views.
A case of the code never having been called with that parameter in an actual scenario.

### All Submissions:

* [x] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
* [x] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
* [ ] I have used pre-commit
* [x] The PR contains **only** my modification and **no other external** commit

### Sh/Runbot:

* [ ] The commits pass test and the branch is green
* [ ] Unit tests have been implemented / standard ones rewritten
* [ ] The Staging is ISO-Prod and will contain only this dev

### Upgrade:

* [ ] The data affected (*if any*) by the changes has been migrated 

### Maintenance reminders:

* Always bump the version of the manifest on the affected modules.
* Notify the developer responsible for the initial development task (when this is relevant).
